### PR TITLE
Added condition to pass empty string if Microsoft Edge is not available.

### DIFF
--- a/lib/local/platform/windows.js
+++ b/lib/local/platform/windows.js
@@ -38,7 +38,7 @@ module.exports = {
     cwd: cwd
   },
   edge: {
-    defaultLocation: path.join(getEdgeDirectory(), 'MicrosoftEdge.exe'),
+    defaultLocation: path.join(getEdgeDirectory() || "", 'MicrosoftEdge.exe'),
     getCommand: function(browser, url) {
       return 'start /wait microsoft-edge:' + url;
     },


### PR DESCRIPTION
Script fails in Windows 10 when Microsoft Edge is not installed (on LTSB ed). https://en.wikipedia.org/wiki/Windows_10_editions